### PR TITLE
Add issue-label-bot template

### DIFF
--- a/.github/issue_label_bot.yaml
+++ b/.github/issue_label_bot.yaml
@@ -1,0 +1,4 @@
+label-alias:
+  bug: 'bug'
+  feature_request: 'enhancement'
+  question: 'should-be-on-forums'


### PR DESCRIPTION
This is a template for [issue-label-bot](https://github.com/marketplace/issue-label-bot). If you enable it on the repo, it'll use AI to categorize issues into bugs, enhancements, and questions which should be on the forums.