### PR TITLE
Remove april fools joke

### DIFF
--- a/src/card-mod.ts
+++ b/src/card-mod.ts
@@ -188,9 +188,6 @@ export class CardMod extends LitElement {
     return html`
       <style>
         ${this._rendered_styles}
-        ${new Date().getDate() === 1 && new Date().getMonth() === 3
-          ? html`:host{transform: rotate(${Math.random() * 2 - 1}deg);}`
-          : ""}
       </style>
     `;
   }


### PR DESCRIPTION
Given that there are already #189 and #190 even though it's not yet the 1st of april in europe and the US, there could be a shitstorm coming. I'm certain that there were only good intentions with this joke so I hope that the discussion will stay civilized.

Anyway, sneaking in a timebomb that breaks the library for a whole day is bad.
It's certainly not as bad as starting to delete files based on the users geoIP as we've seen recently with popular npm packages, but it's still very much not good.

Please don't do that as it erodes trust.
Without trust in the maintainers, people might stop updating their software to avoid these kinds of surprises, as reviewing all commits of all software used every time simply isn't feasible for most.
In fact, with a project as end-user-focussed as home assistant, a lot of users of this card likely won't be able to do said code review at all. 

What makes matters worse is that you're the author of a lot of high quality and widely used lovelace cards, which is why there are a lot of people trusting you based on that work and the standing in the community.

Do we now have to review all those cards? Do we have to question other core community members now?

I know it's just a rotation by a random angle but I hope you see my point here.
The fact that it does something unexpected which was hidden in some other commit is just frightening even if the thing that is done isn't that harmful.