### PR TITLE
fix error when setConfig is read-only

### DIFF
--- a/src/patch/ha-card.ts
+++ b/src/patch/ha-card.ts
@@ -36,12 +36,16 @@ customElements.whenDefined("ha-card").then(() => {
       if (pn.setConfig && !pn.setConfig.cm_patched) {
         // Patch the setConfig function to get live updates in GUI editor
         const _setConfig = pn.setConfig;
-        pn.setConfig = function (config: any, ...rest) {
-          _setConfig.bind(this)(config, ...rest);
-          cardMod.variables = { config };
-          cardMod.styles = config.card_mod?.style || {};
-        };
-        pn.setConfig.cm_patched = true;
+        try {
+            pn.setConfig = function (config: any, ...rest) {
+            _setConfig.bind(this)(config, ...rest);
+            cardMod.variables = { config };
+            cardMod.styles = config.card_mod?.style || {};
+            };
+            pn.setConfig.cm_patched = true;
+        } catch (error) {
+          console.warn(error);
+        }
       }
 
       if (pn.update && !pn.update.cm_patched) {

--- a/src/patch/hui-card-element-editor.ts
+++ b/src/patch/hui-card-element-editor.ts
@@ -12,30 +12,34 @@ customElements.whenDefined("hui-card-element-editor").then(() => {
     // Catch and patch the configElement
     if (retval) {
       const _setConfig = retval.setConfig;
-      retval.setConfig = function (config: any, ...rest) {
-        // Strip card_mod from the data that's sent to the config element
-        // and put it back after the config has been checked
-        const newConfig = JSON.parse(JSON.stringify(config));
-        this._cardModData = {
-          card: newConfig.card_mod,
-          entities: [],
-        };
-        if (newConfig.entities) {
-          for (const [i, e] of newConfig.entities?.entries()) {
-            this._cardModData.entities[i] = e.card_mod;
-            delete e.card_mod;
-          }
-        }
-        delete newConfig.card_mod;
+      try {
+          retval.setConfig = function (config: any, ...rest) {
+            // Strip card_mod from the data that's sent to the config element
+            // and put it back after the config has been checked
+            const newConfig = JSON.parse(JSON.stringify(config));
+            this._cardModData = {
+              card: newConfig.card_mod,
+              entities: [],
+            };
+            if (newConfig.entities) {
+              for (const [i, e] of newConfig.entities?.entries()) {
+                this._cardModData.entities[i] = e.card_mod;
+                delete e.card_mod;
+              }
+            }
+            delete newConfig.card_mod;
 
-        _setConfig.bind(this)(newConfig, ...rest);
-        if (newConfig.entities) {
-          for (const [i, e] of newConfig.entities?.entries()) {
-            if (this._cardModData.entities[i])
-              e.card_mod = this._cardModData.entities[i];
-          }
-        }
-      };
+            _setConfig.bind(this)(newConfig, ...rest);
+            if (newConfig.entities) {
+              for (const [i, e] of newConfig.entities?.entries()) {
+                if (this._cardModData.entities[i])
+                  e.card_mod = this._cardModData.entities[i];
+              }
+            }
+          };
+      } catch (error) {
+        console.warn(error);
+      }
     }
     return retval;
   };


### PR DESCRIPTION
When the method `setConfig` is read-only card-mod crashes.
I wrapped the variable Assignment in a try-catch.

```
card-mod.js:5 Uncaught (in promise) TypeError: Cannot set property setConfig of #<z> which has only a getter
    at card-mod.js:5:1163
```