### PR TITLE
removing extra - for card-mod-icon-dim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ entities:
 
 With card-mod installed, the `<ha-icon>` element - used e.g. by `entities`, `glance` and many more cards - will set it's icon to the value found in the CSS variable `--card-mod-icon` (if present).
 
-It will also set the icon color to the value found in the CSS variable `--card-mod-icon-color` if present. This ignores entity state, but will still dim unless you also set `---card-mod-icon-dim` to `none`.
+It will also set the icon color to the value found in the CSS variable `--card-mod-icon-color` if present. This ignores entity state, but will still dim unless you also set `--card-mod-icon-dim` to `none`.
 
 ```yaml
 - entity: light.bed_light


### PR DESCRIPTION
really minor pull request here. i was just looking over the 3.2.0 release notes and noticed the `card-mod-icon-dim` feature, which is great and i want to play with it! the README had a reference to it with an extra `-`... so this just cleans that up.

thanks for all your great work on these home assistant cards! you're work is great and i use a LOT of them. 🙏🏼 