### PR TITLE
Correctly detect script imports

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -168,9 +168,9 @@ export function getResources() {
   const retval = [];
   for (const script of scriptElements) {
     if (script?.innerText?.trim()?.startsWith("import(")) {
-      const imports = script.innerText.split("\n")?.map((e) => e.trim());
+      const imports = script.innerText.split(/[\n;]/)?.map((e) => e.trim());
       for (const imp of imports) {
-        retval.push(imp.replace(/^import\(\"/, "").replace(/\"\);/, ""));
+        retval.push(imp.replace(/^import\(\"/, "").replace(/\"\)/, ""));
       }
     }
   }


### PR DESCRIPTION
The `getResources` function does not correctly list all scripts If all `import` statements are rendered in one line. So split on both newline and `;` characters.

This should fix the problem where `You may not be getting optimal performance out of card-mod.` is still printed in the console even the js is loaded in frontend via `extra_module_url`.