### PR TITLE
Wait until hass initialized before merging card and theme styles

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -62,13 +62,14 @@ export async function applyToElement(
 export async function get_theme(root: CardMod): Promise<Styles> {
   if (!root.type) return null;
 
+  const hs = await hass();
+  if (!hs) return {};
+
   const el = root.parentElement ? root.parentElement : root;
   const theme = window
     .getComputedStyle(el)
     .getPropertyValue("--card-mod-theme");
 
-  const hs = await hass();
-  if (!hs) return {};
   const themes = hs?.themes.themes ?? {};
   if (!themes[theme]) return {};
 


### PR DESCRIPTION
This pull request may fix issues described in #152 (in some cases).

I experienced similar behavior - styles not being applied after page refresh - on one of my dashboards. I suspect some race condition occurs when `card-mod` styles are being applied as styles are correctly applied on some of my dashboards and randomly on others.

Please note that I am using a custom `card-mod` theme and the missing styles are set globally in the theme.

I noticed that sometimes `card-mod` did not read value of CSS variable `--card-mod-theme` correctly when debugging the issue. Moving `await hass()` in front of `getPropertyValue("--card-mod-theme")` appears to block the app for just enough time that variable `--card-mod-theme` is being set and can be read by `card-mod`.

It is quite possible that this is not a definite fix for #152. `await hass()` call postpones variable read for a few ticks and this may suffice in my particular case - refreshing page now works in 100% of my cases. YMMV.