### PR TITLE
Fix reactivity issues in editor

### DIFF
--- a/src/patch/hui-card-element-editor.ts
+++ b/src/patch/hui-card-element-editor.ts
@@ -5,30 +5,38 @@ class ConfigElementPatch extends LitElement {
   _cardModData?;
 
   setConfig(_orig, config, ...rest) {
-    const newConfig = JSON.parse(JSON.stringify(config));
-
     // Save card_mod config
     this._cardModData = {
-      card: newConfig.card_mod,
+      card: config.card_mod,
       entities: [],
     };
-    delete newConfig.card_mod;
+    
+    // Temporarily remove top-level card_mod
+    const topLevelCardMod = config.card_mod;
+    delete config.card_mod;
 
     // Save card_mod config for individual entities
-    if (Array.isArray(newConfig.entities)) {
-      for (const [i, e] of newConfig.entities?.entries?.()) {
+    if (Array.isArray(config.entities)) {
+      for (const [i, e] of config.entities?.entries?.()) {
         this._cardModData.entities[i] = e.card_mod;
         delete e.card_mod;
       }
     }
 
-    _orig(newConfig, ...rest);
+    // Call original function with modified config
+    _orig(config, ...rest);
+
+    // Restore card_mod configurations
+    if (topLevelCardMod) {
+      config.card_mod = topLevelCardMod;
+    }
 
     // Restore card_mod config for entities
-    if (Array.isArray(newConfig.entities)) {
-      for (const [i, e] of newConfig.entities?.entries?.()) {
-        if (this._cardModData?.entities[i])
+    if (Array.isArray(config.entities)) {
+      for (const [i, e] of config.entities?.entries?.()) {
+        if (this._cardModData?.entities[i]) {
           e.card_mod = this._cardModData.entities[i];
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem

The current implementation creates a deep copy of the configuration object using `JSON.parse(JSON.stringify())` before processing it. This breaks reactivity by losing the reference to the original object, preventing proper tracking of changes, which causes unwanted behavior down the chain..

## Solution
This PR modifies the `setConfig` method to work directly with the original configuration object instead of creating a copy. The card_mod configurations are temporarily removed and stored, then restored after the original function call. This maintains proper reactivity while still achieving the desired functionality.


### Before

https://github.com/user-attachments/assets/a2c4e854-f280-4f82-bc42-00f6193a99ce


### After

https://github.com/user-attachments/assets/84bb7903-8215-4e70-8180-c4870b710b92
