### PR TITLE
Manage patch state at window level

### DIFF
--- a/src/helpers/patch_function.ts
+++ b/src/helpers/patch_function.ts
@@ -1,6 +1,6 @@
 (window as any).cardMod_patch_state = (window as any).cardMod_patch_state || {};
 
-const patchState: Record<string, Boolean> = (window as any).cardMod_patch_state;
+const patchState: Record<string, boolean> = (window as any).cardMod_patch_state;
 
 const patch_method = function (obj, method, override) {
   if (method === "constructor") return;


### PR DESCRIPTION
Prevents patching code running again when card-mod is loaded twice by browser, which will happen if say using Frontend module and dashboard resource, but the URLs don't match EXACTLY. 

There are many issues out in the wild which are actually due to this. Refresh cache does not fix as the issue is how Browsers run car-mod twice when URLs not exact. There may still be issues of old running code depending on which card-mod Browers run, but this can be reviewed in console and IS fixed by cache refresh.