### PR TITLE
Revert removing card_mod from applying at conditional row config.

### DIFF
--- a/src/patch/hui-entities-card.ts
+++ b/src/patch/hui-entities-card.ts
@@ -11,7 +11,7 @@ Patch the hui-entities-card specifically in order to handle individual styling o
 class HuiEntitiesCardPatch extends ModdedElement {
   _renderEntity(_orig, config, ...rest) {
     const retval = _orig?.(config, ...rest);
-    if (config?.type === "custom:mod-card" || config?.type === "conditional") return retval;
+    if (config?.type === "custom:mod-card") return retval;
 
     if (!retval?.values) return retval;
     const row = retval.values[1];


### PR DESCRIPTION
Makes for conditional row change to be non-breaking. Beta release notes to be updated.