### PR TITLE
Fix hui-card card element config check fix introduced in 4.0.1-beta.1 to match v3/ha-card

### DIFF
--- a/src/patch/hui-card.ts
+++ b/src/patch/hui-card.ts
@@ -18,7 +18,7 @@ class HuiCardPatch extends ModdedElement {
     if (EXCLUDED_CARDS.includes(this.config?.type?.toLowerCase())) return;
 
     const element = this._element as any;
-    const config = element?._config || element?.config || this.config;
+    const config = element?.config || element?._config || this.config;
     const cls = `type-${config?.type?.replace?.(":", "-")}`;
 
     await apply_card_mod(


### PR DESCRIPTION
v4.0.1-beta.1 introduced checking for card's config to support cards that adjust their config. v3/ha-card order is `.config` before `._config`. Some cards use `._config` but it is not a copy of `.config`. `custom:map-card` is such a card so v4.0.1-beta.1 will have broken card_mod for `custom:map-card`