### PR TITLE
Support Card Mod Background Theme Styling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import "./patch/hui-picture-elements-card";
 
 import "./patch/ha-icon";
 import "./patch/hui-view";
+import "./patch/hui-view-background";
 import "./patch/hui-root";
 // To include in 4.2.2 and leave 4.2.1 just as a bugfix release for the 4.2.0 duplicate patching warning
 // import "./patch/ha-drawer";

--- a/src/patch/hui-view-background.ts
+++ b/src/patch/hui-view-background.ts
@@ -1,0 +1,20 @@
+import { ModdedElement, apply_card_mod } from "../helpers/apply_card_mod";
+import { patch_element } from "../helpers/patch_function";
+
+/*
+Patch hui-view-background for theme styling
+
+This element was introduced in HA 2024.x to handle view background rendering.
+It manages the --view-background CSS variable that controls the dashboard background.
+
+There is no style passed to apply_card_mod here, everything comes only from themes.
+
+*/
+
+@patch_element("hui-view-background")
+class HuiViewBackgroundPatch extends ModdedElement {
+  updated(_orig, ...args) {
+    _orig?.(...args);
+    apply_card_mod(this, "view", undefined, {}, false);
+  }
+}


### PR DESCRIPTION
## Add patch for `hui-view-background` element

### Problem

Really Trying to contribute what was a journey to why I couldn't have Jinja in themes when everything pointed to Card Mod being able to do this and being able to change the background of everything except the theme.

Starting in HA 2024.x, the frontend introduced a new `hui-view-background` custom element that handles view background rendering. This element manages the `--view-background` CSS variable, which controls the dashboard background.

Because card-mod didn't patch this element, `card-mod-view` theme styles (including Jinja templates) had no effect on view backgrounds in newer HA versions. Card-level styling continued to work fine.

### Test
Custom Theme
```
weather_dynamic:
  card-mod-theme: weather_dynamic
  card-mod-view: |
    {% set weather = states('weather.bkl') %}
    :host {
      {% if weather == 'clear-night' %}
        --view-background: linear-gradient(-45deg, #0f0c29, #302b63, #24243e, #0f0c29) !important;
      {% elif weather == 'sunny' %}
        --view-background: linear-gradient(-45deg, #1a6dd4, #56b4d3, #f0c27f, #4ecdc4) !important;
      {% elif weather == 'partlycloudy' %}
        --view-background: linear-gradient(-45deg, #616d86, #96a5c4, #c4cfe0, #7b8ba6) !important;
      {% elif weather == 'cloudy' %}
        --view-background: linear-gradient(-45deg, #4a5568, #718096, #a0aec0, #4a5568) !important;
      {% elif weather in ['rainy', 'pouring', 'lightning-rainy', 'lightning'] %}
        --view-background: linear-gradient(-45deg, #1a1a2e, #16213e, #0f3460, #1a1a2e) !important;
      {% elif weather == 'snowy' %}
        --view-background: linear-gradient(-45deg, #e0e5ec, #c4ccd4, #dfe6ed, #b8c6d6) !important;
      {% elif weather == 'fog' %}
        --view-background: linear-gradient(-45deg, #8e9eab, #a8b8c8, #cbd5e0, #8e9eab) !important;
      {% else %}
        --view-background: linear-gradient(-45deg, #2c3e50, #3498db, #2980b9, #2c3e50) !important;
      {% endif %}
    }
```
Custom Lovelace Dashboard
```
views:
  - title: Home
    path: living-room
    type: sections
    max_columns: 3
    theme: weather_dynamic
```
Works as intended. Confirmed working with a `card-mod-view` theme using Jinja templates to dynamically change the dashboard background based on weather entity state.


Tested on HA 2026.3.4 with `sections` view type.