### PR TITLE
build: target modern browsers so async/await stays native (-45% bundle)

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -16,7 +16,28 @@ export default {
     nodeResolve(),
     json(),
     typescript(),
-    getBabelOutputPlugin({ presets: ["@babel/preset-env"] }),
+    // Without explicit targets, preset-env downlevels to ES5 and rewrites every
+    // async function into a regenerator state machine. That machinery showed up
+    // as ~165ms of asyncGeneratorStep/tryCatch/wrap on a single dashboard load,
+    // and it is pure waste: Home Assistant itself only runs on browsers that
+    // support native async/await (see the isModern check in HA's index.html).
+    // These targets mirror that set, so async stays native.
+    getBabelOutputPlugin({
+      presets: [
+        [
+          "@babel/preset-env",
+          {
+            targets: {
+              chrome: "109",
+              edge: "139",
+              firefox: "140",
+              safari: "26",
+            },
+            bugfixes: true,
+          },
+        ],
+      ],
+    }),
     !dev && terser({ format: { comments: false } }),
   ],
 };


### PR DESCRIPTION
#### TLDR
This PR changes the build to target modern browsers, so that `async`/`await` is emitted natively instead of being transpiled to a regenerator state machine. The bundle size drops from 99 KB to 54 KB, and the Chrome performance profile shows ~165 ms of regenerator overhead is gone.

### Why it's safe to do

Without an explicit `targets` option, `@babel/preset-env` downlevels to ES5. That output
can't reach a browser that would need it: Home Assistant only serves its frontend to
browsers with native `async`/`await` support — see the `isModern` check in HA's
`index.html`. The `targets` added here mirror that same browser set.

One file touched: `rollup.config.mjs`.

| | before | after | |
|---|---|---|---|
| `card-mod.js` | 99,373 B | 53,840 B | **-45.8%** |
| regenerator frames in profile | ~165 ms | gone | |

### Risk

Low, but it does move the browser support floor of the published bundle, so it's worth a
second opinion. If there's an entry path that bypasses HA's `isModern` check, this is the
wrong trade and I've missed it.

No rebuilt `card-mod.js` is committed — only release commits regenerate it. The size above
is from `npm run build` on this branch.
