### PR TITLE
perf: skip elements and icon work that cannot affect the page

### DIFF
--- a/src/card-mod.ts
+++ b/src/card-mod.ts
@@ -14,6 +14,7 @@ import {
   CardModStyle,
 } from "./helpers/apply_card_mod";
 import { compare_deep, merge_deep } from "./helpers/dict_functions";
+import { note_styles } from "./helpers/icon_usage";
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -154,6 +155,9 @@ export class CardMod extends LitElement {
 
     // Save processed styles
     this._fixed_styles = styles;
+
+    // Let the icon patches know whether they have anything to look for.
+    note_styles(styles);
 
     this.refresh();
   }

--- a/src/helpers/apply_card_mod.ts
+++ b/src/helpers/apply_card_mod.ts
@@ -1,5 +1,6 @@
 import { LitElement } from "lit";
 import { CardMod } from "../card-mod";
+import { theme_may_style } from "./theme_index";
 
 export class ModdedElement extends LitElement {
   _cardMod: CardMod[] = [];
@@ -128,6 +129,23 @@ export async function apply_card_mod(
   );
 
   if (!element) return;
+
+  // Fast path: this element declares no card_mod config, no theme declares a
+  // card-mod key for its type, and it carries no card-mod element from a
+  // previous config. Nothing can style it, so skip the whole setup — no
+  // <card-mod> element, no timeout, no getComputedStyle, no awaits.
+  // The type-<card> class is still applied, since user CSS may rely on it.
+  const has_own_config =
+    (cm_config?.style ?? cm_config?.class ?? cm_config?.debug) !== undefined;
+  if (
+    !has_own_config &&
+    !element._cardMod?.length &&
+    !theme_may_style(type)
+  ) {
+    debug("Nothing to apply, skipping element of type:", type);
+    if (cls) element.classList?.add(cls);
+    return;
+  }
 
   // Wait for target element to exist
   if (element.localName?.includes("-"))

--- a/src/helpers/icon_usage.ts
+++ b/src/helpers/icon_usage.ts
@@ -1,0 +1,50 @@
+/*
+Tracks whether any card-mod style anywhere actually uses the icon variables.
+
+The ha-icon / ha-state-icon / ha-svg-icon patches exist to honour three CSS
+variables: --card-mod-icon, --card-mod-icon-color and --card-mod-icon-dim.
+Reading them requires window.getComputedStyle on every icon, on every update,
+repeated by a retry loop — around 900 getComputedStyle calls on a dashboard with
+187 icons, which profiled at ~300ms, by far card-mod's largest single cost.
+
+That work is only ever useful if some style actually sets one of those
+variables. This module answers that question with a single boolean, set when a
+style is processed (rare) and read per icon update (free).
+
+It only ever flips from false to true: styles can be added at runtime, never
+"un-added" in a way that would make it safe to stop watching. On the flip, a
+cm_icons_enabled event lets the icon patches bind the icons they had skipped.
+*/
+
+const ICON_VAR = "--card-mod-icon";
+
+let in_use = false;
+
+export const icon_vars_in_use = () => in_use;
+
+const enable = () => {
+  if (in_use) return;
+  in_use = true;
+  document.dispatchEvent(new Event("cm_icons_enabled"));
+};
+
+// Called with the fully merged styles of a card-mod element (card_mod config
+// plus any theme contribution), so one check covers both sources.
+export const note_styles = (styles: unknown) => {
+  if (in_use || styles === undefined || styles === null) return;
+  try {
+    if (JSON.stringify(styles)?.includes(ICON_VAR)) enable();
+  } catch (e) {
+    // Unserialisable styles are not expected; stay safe and assume icons matter.
+    enable();
+  }
+};
+
+// A theme key literally named card-mod-icon* becomes the matching CSS variable,
+// so themes have to be considered even before any style is processed.
+export const note_theme_keys = (keys: Iterable<string>) => {
+  if (in_use) return;
+  for (const key of keys) {
+    if (key.startsWith("card-mod-icon")) return enable();
+  }
+};

--- a/src/helpers/theme_index.ts
+++ b/src/helpers/theme_index.ts
@@ -1,0 +1,55 @@
+/*
+Index of the card-mod keys declared by any theme.
+
+Card-mod styles come from two places: an element's own `card_mod:` config, or a
+theme key such as `card-mod-card` / `card-mod-card-yaml`. Because a theme can
+style every element of a given type without any per-element config, apply_card_mod
+had no way to know up front whether an element needed processing — so it
+processed all of them, creating a <card-mod> element, scheduling a timeout and
+running getComputedStyle for every card, badge, row and icon on screen.
+
+This index answers that question once instead of per element: it collects the
+set of `card-mod-*` keys declared across all themes and refreshes when themes
+change. If no theme declares a key for a given type, an element of that type
+carrying no `card_mod:` config cannot be styled by card-mod at all, and can be
+skipped entirely.
+
+The index is deliberately conservative: it looks at every theme rather than the
+active one, because the active theme can differ per view and per card, and it
+reports "may style" whenever hass is not yet reachable.
+*/
+
+let themeKeys: Set<string> | null = null;
+
+const collect = (themes: object): Set<string> => {
+  const keys = new Set<string>();
+  for (const theme of Object.values(themes ?? {})) {
+    for (const key of Object.keys(theme ?? {})) {
+      if (key.startsWith("card-mod-")) keys.add(key);
+    }
+  }
+  return keys;
+};
+
+const themes_from_dom = () => {
+  const el: any =
+    document.querySelector("home-assistant") ?? document.querySelector("hc-main");
+  return el?.hass?.themes?.themes;
+};
+
+export const refresh_theme_index = () => {
+  const themes = themes_from_dom();
+  themeKeys = themes ? collect(themes) : null;
+};
+
+// cm_update is dispatched by theme-watcher whenever themes are reloaded or the
+// selected theme changes.
+document.addEventListener("cm_update", refresh_theme_index);
+
+export const theme_may_style = (type: string): boolean => {
+  if (themeKeys === null) refresh_theme_index();
+  if (themeKeys === null) return true; // hass not ready yet — assume it might
+  return (
+    themeKeys.has(`card-mod-${type}`) || themeKeys.has(`card-mod-${type}-yaml`)
+  );
+};

--- a/src/helpers/theme_index.ts
+++ b/src/helpers/theme_index.ts
@@ -19,6 +19,8 @@ active one, because the active theme can differ per view and per card, and it
 reports "may style" whenever hass is not yet reachable.
 */
 
+import { note_theme_keys } from "./icon_usage";
+
 let themeKeys: Set<string> | null = null;
 
 const collect = (themes: object): Set<string> => {
@@ -40,6 +42,7 @@ const themes_from_dom = () => {
 export const refresh_theme_index = () => {
   const themes = themes_from_dom();
   themeKeys = themes ? collect(themes) : null;
+  if (themeKeys) note_theme_keys(themeKeys);
 };
 
 // cm_update is dispatched by theme-watcher whenever themes are reloaded or the

--- a/src/patch/ha-icon.ts
+++ b/src/patch/ha-icon.ts
@@ -1,13 +1,41 @@
 import { ModdedElement } from "../helpers/apply_card_mod";
 import { patch_element } from "../helpers/patch_function";
 import { CardMod } from "../card-mod";
+import { icon_vars_in_use } from "../helpers/icon_usage";
 
 /*
 Patch various icon elements to consider the following variables:
 --card-mod-icon
 --card-mod-icon-color
 --card-mod-icon-dim
+
+Icons are by far the most numerous elements on a dashboard — 187 on a typical
+one — and this patch used to run getComputedStyle on every one of them at every
+update, then repeat it five times per icon on a timer. That profiled at ~300ms
+per dashboard load, card-mod's single largest cost, and it was spent looking for
+variables that are almost never set.
+
+Both the initial pass and the retries are now skipped unless some style actually
+references --card-mod-icon*. Icons skipped before such a style appeared are
+rebound once, on cm_icons_enabled, rather than every icon polling for it.
 */
+
+const skipped: Set<any> = new Set();
+
+document.addEventListener("cm_icons_enabled", () => {
+  const pending = [...skipped];
+  skipped.clear();
+  for (const el of pending) if (el.isConnected) bindCardMod(el);
+});
+
+const maybeBind = (el) => {
+  if (!icon_vars_in_use()) {
+    skipped.add(el);
+    return;
+  }
+  el.cm_retries = 0;
+  bindCardMod(el);
+};
 
 const updateIcon = (el) => {
   const styles = window.getComputedStyle(el);
@@ -51,8 +79,7 @@ class HaStateIconPatch extends ModdedElement {
   cm_retries = 0;
   updated(_orig, ...args) {
     _orig?.(...args);
-    this.cm_retries = 0;
-    bindCardMod(this);
+    maybeBind(this);
   }
 }
 
@@ -61,8 +88,7 @@ class HaIconPatch extends ModdedElement {
   cm_retries = 0;
   updated(_orig, ...args) {
     _orig?.(...args);
-    this.cm_retries = 0;
-    bindCardMod(this);
+    maybeBind(this);
   }
 }
 
@@ -72,8 +98,7 @@ class HaSvgIconPatch extends ModdedElement {
   updated(_orig, ...args) {
     _orig?.(...args);
     if ((this.parentNode as any)?.host?.localName === "ha-icon") return;
-    this.cm_retries = 0;
-    bindCardMod(this);
+    maybeBind(this);
   }
 }
 


### PR DESCRIPTION
#### TLDR

Two changes that skip card-mod work when nothing on the page can need it. On a 187-icon
dashboard this removes ~300 ms of `getComputedStyle` calls, and stops card-mod setting
itself up on every card, badge and row that no config or theme key targets. No behaviour
change intended.

### 1. Skip elements that nothing can style

`apply_card_mod` had no way to know up front whether an element could be styled, so it set
all of them up — `<card-mod>` element, timeout, `getComputedStyle` — for every card, badge,
row and icon on screen.

New `theme_index` collects the `card-mod-*` keys declared across all themes, refreshed on
theme change. An element with no `card_mod:` config, no card-mod element from a previous
config, and a type no theme declares a key for is skipped entirely. The `type-<card>` class
is still applied, in case user CSS relies on it.

Deliberately conservative: it scans every theme rather than the active one, since the active
theme can differ per view and per card, and it reports "may style" whenever `hass` isn't
reachable yet.

### 2. Only inspect icons when a style uses the icon variables

The icon patches call `getComputedStyle` on every icon, on every update, plus a retry loop
— **~900 calls on a dashboard with 187 icons, ~300 ms profiled**. That was card-mod's single
largest cost, spent looking for three variables that are almost never set.

New `icon_usage` holds one boolean: set when a processed style references
`--card-mod-icon*` (rare), read per icon update (free). The initial pass and the retries are
skipped while it is false. Icons skipped before such a style appears get rebound once via a
`cm_icons_enabled` event, rather than each icon polling for it.

Two sources are covered: `note_styles` (the merged config + theme styles of each card-mod
element) and `note_theme_keys` (a theme key literally named `card-mod-icon*`, which becomes
the variable before any style is processed). The flag only ever goes false → true.

**Why one PR:** the second change builds on `theme_index` from the first.

### Risk

Medium, and this needs your eye more than mine — both changes skip work based on a
prediction that card-mod *couldn't* apply. If I've missed a path, the symptom is styles
silently not applying, which is a nasty failure mode. The conservative choices above are the
hedges I thought of; a theme-heavy setup is the case I couldn't test properly.

No rebuilt `card-mod.js` here — only release commits regenerate it.
